### PR TITLE
Add scaling, positioning and pixel format options to API

### DIFF
--- a/api/api.h
+++ b/api/api.h
@@ -7,30 +7,80 @@ namespace svg_services {
 PFC_DECLARE_EXCEPTION(exception_svg_services, pfc::exception,
                       "SVG services error");
 
-class NOVTABLE svg_renderer : public service_base {
+struct Size {
+  double width{};
+  double height{};
+};
+
+struct Rect {
+  double x{};
+  double y{};
+  double width{};
+  double height{};
+};
+
+enum class PixelFormat {
+  BGRA,
+  PRGBA,
+};
+
+enum class ScalingMode {
+  None,
+  Fit,
+  Zoom,
+  Stretch,
+};
+
+enum class Position {
+  TopLeft,
+  Centred,
+};
+
+class NOVTABLE svg_document : public service_base {
+public:
+  [[nodiscard]] virtual Size get_size() const noexcept = 0;
+
+  [[nodiscard]] virtual Rect get_view_box() const noexcept = 0;
+
+  /**
+   * \brief Render the SVG document
+   *
+   * \param output_width The width of the output bitmap
+   * \param output_height The height of the output bitmap
+   * \param position Where to position the rendered SVG in the output bitmap
+   * \param scaling_mode The scaling mode to use to fit the SVG to the output
+   * \param output_pixel_format The pixel format to render the SVG in
+   * bitmap \param output_buffer Pointer to a writable buffer of at least size
+   *                      render_width * render_height * 4.
+   *                      This will receive a 32-bpp bitmap.
+   * \param output_buffer_size Size of the output buffer in bytes
+   */
+  virtual void render(int output_width, int output_height, Position position,
+                      ScalingMode scaling_mode, PixelFormat output_pixel_format,
+                      void *output_buffer, size_t output_buffer_size) const = 0;
+
+  FB2K_MAKE_SERVICE_INTERFACE(svg_document, service_base);
+};
+
+class NOVTABLE svg_services : public service_base {
 public:
   /**
-   * \brief Render an SVG document
+   * \brief Open an SVG document
    *
    * \param svg_data Pointer to a buffer containing the SVG document,
    * UTF-8-encoded
    *
    * \param svg_data_size Size of the SVG data in the buffer in bytes
-   * \param render_width The width to render the SVG at
-   * \param render_height The height to render the SVG at
-   * \param output_buffer Pointer to a writable buffer of at least size
-   *                      render_width * render_height * 4.
-   *                      This will receive a 32-bpp BGRA bitmap.
-   * \param output_buffer_size Size of the output buffer in bytes
    */
-  virtual void render(const void *svg_data, size_t svg_data_size,
-                      int render_width, int render_height, void *output_buffer,
-                      size_t output_buffer_size) const = 0;
+  virtual svg_document::ptr open(const void *svg_data,
+                                 size_t svg_data_size) const = 0;
 
-  FB2K_MAKE_SERVICE_INTERFACE_ENTRYPOINT(svg_renderer)
+  FB2K_MAKE_SERVICE_INTERFACE_ENTRYPOINT(svg_services)
 };
 
-DECLARE_CLASS_GUID(svg_renderer, 0x3a5b8268, 0x408c, 0x4955, 0xbe, 0x5d, 0xa5,
-                   0x52, 0xf1, 0x2d, 0x64, 0xa5);
+DECLARE_CLASS_GUID(svg_document, 0x9d367cb6, 0x50ca, 0x4511, 0xa0, 0x2f, 0x9f,
+                   0x57, 0x3f, 0x9a, 0x2a, 0x33);
+DECLARE_CLASS_GUID(svg_services, 0x8953198d, 0xf39d, 0x4186, 0xa9, 0xa3, 0xe5,
+                   0xa6, 0x7c, 0xa6, 0x14, 0xa1);
 
 } // namespace svg_services

--- a/foo_svg_services/main.cpp
+++ b/foo_svg_services/main.cpp
@@ -16,7 +16,7 @@
 
 namespace svg_services {
 
-DECLARE_COMPONENT_VERSION("SVG services", svg_services::version, "compiled: " COMPILATION_DATE);
+DECLARE_COMPONENT_VERSION("SVG services", version, "compiled: " COMPILATION_DATE);
 
 const std::unordered_map<int32_t, const char*> resvg_error_messages = {
     {RESVG_ERROR_NOT_AN_UTF8_STR, "Only UTF-8 files are supported"},
@@ -74,9 +74,69 @@ void prgba_to_bgra(void* data, int width, int height)
     }
 }
 
-class svg_renderer_impl : public svg_renderer {
-    void render(const void* svg_data, size_t svg_data_size, int render_width, int render_height, void* output_buffer,
-        size_t output_buffer_size) const override
+class SVGDocumentImpl : public svg_document {
+public:
+    explicit SVGDocumentImpl(resvg_render_tree* tree) : m_tree(tree){};
+
+    [[nodiscard]] Size get_size() const noexcept override
+    {
+        const auto size = resvg_get_image_size(m_tree);
+        return {size.width, size.height};
+    }
+
+    [[nodiscard]] Rect get_view_box() const noexcept override
+    {
+        const auto view_box = resvg_get_image_viewbox(m_tree);
+        return {view_box.x, view_box.y, view_box.width, view_box.height};
+    }
+
+    void render(int output_width, int output_height, Position position, ScalingMode scaling_mode,
+        PixelFormat output_pixel_format, void* output_buffer, size_t output_buffer_size) const override
+    {
+        if (output_width == 0 || output_height == 0)
+            return;
+
+        const auto size = get_size();
+        const auto wider_than_original = static_cast<float>(size.width) / static_cast<float>(size.height)
+            < static_cast<float>(output_width) / static_cast<float>(output_height);
+
+        const auto [width_scaling_factor, height_scaling_factor]
+            = [output_width, output_height, size, scaling_mode, wider_than_original]() {
+                  const auto width_ratio = static_cast<double>(output_width) / static_cast<double>(size.width);
+                  const auto height_ratio = static_cast<double>(output_height) / static_cast<double>(size.height);
+
+                  if (scaling_mode == ScalingMode::None)
+                      return std::make_tuple(1.0, 1.0);
+
+                  if (scaling_mode == ScalingMode::Zoom) {
+                      auto scaling_factor = wider_than_original ? width_ratio : height_ratio;
+                      return std::make_tuple(scaling_factor, scaling_factor);
+                  }
+
+                  if (scaling_mode == ScalingMode::Fit) {
+                      auto scaling_factor = wider_than_original ? height_ratio : width_ratio;
+                      return std::make_tuple(scaling_factor, scaling_factor);
+                  }
+
+                  return std::make_tuple(width_ratio, height_ratio);
+              }();
+
+        const auto transform = resvg_transform{width_scaling_factor, 0, 0, height_scaling_factor,
+            position == Position::TopLeft ? 0.0 : (output_width - width_scaling_factor * size.width) / 2.0,
+            position == Position::TopLeft ? 0.0 : (output_height - height_scaling_factor * size.height) / 2.0};
+
+        resvg_render(m_tree, resvg_fit_to{}, transform, output_width, output_height, static_cast<char*>(output_buffer));
+
+        if (output_pixel_format == PixelFormat::BGRA)
+            prgba_to_bgra(output_buffer, output_width, output_height);
+    }
+
+private:
+    resvg_render_tree* m_tree{};
+};
+
+class SVGServicesImpl : public svg_services {
+    svg_document::ptr open(const void* svg_data, size_t svg_data_size) const override
     {
         resvg_options* opt = resvg_options_create();
 
@@ -85,20 +145,12 @@ class svg_renderer_impl : public svg_renderer {
         resvg_render_tree* tree{};
         check_resvg_result(resvg_parse_tree_from_data(static_cast<const char*>(svg_data), svg_data_size, opt, &tree));
 
-        const auto size = resvg_get_image_size(tree);
-        const auto fit_to_height = static_cast<float>(size.width) / static_cast<float>(size.height)
-            < static_cast<float>(render_width) / static_cast<float>(render_height);
-        const auto fit_to = resvg_fit_to{fit_to_height ? RESVG_FIT_TO_TYPE_HEIGHT : RESVG_FIT_TO_TYPE_WIDTH,
-            static_cast<float>(fit_to_height ? render_height : render_width)};
-
-        resvg_render(
-            tree, fit_to, resvg_transform_identity(), render_width, render_height, static_cast<char*>(output_buffer));
-        prgba_to_bgra(output_buffer, render_width, render_height);
+        return fb2k::service_new<SVGDocumentImpl>(tree);
     }
 };
 
 namespace {
-service_factory_t<svg_renderer_impl> _;
+service_factory_t<SVGServicesImpl> _;
 }
 
 } // namespace svg_services


### PR DESCRIPTION
This:

- reorganises the API into an entry-point service and an SVG document object
- adds the ability to output bitmaps with pre-multiplied alpha
- adds the ability to specify no, zoom or stretch scaling (instead of just scaling to fit)
- adds the ability to centre rendered SVGs in the output bitmap