### PR TITLE
Add text support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,4 @@
 This component provides an SVG renderer, for use by other foobar2000 components.
 It is currently experimental as no stable versions of it have been released.
 
-[resvg](https://github.com/RazrFalcon/resvg) is used to render SVGs. Text
-currently isn’t supported.
+[resvg](https://github.com/RazrFalcon/resvg) is used to render SVGs.

--- a/api/api.h
+++ b/api/api.h
@@ -67,8 +67,7 @@ public:
   /**
    * \brief Open an SVG document
    *
-   * \param svg_data Pointer to a buffer containing the SVG document,
-   * UTF-8-encoded
+   * \param svg_data Pointer to a buffer containing the SVG document
    *
    * \param svg_data_size Size of the SVG data in the buffer in bytes
    */

--- a/foo_svg_services/main.cpp
+++ b/foo_svg_services/main.cpp
@@ -85,6 +85,18 @@ class SVGDocumentImpl : public svg_document {
 public:
     explicit SVGDocumentImpl(resvg_render_tree* tree) : m_tree(tree) {}
 
+    SVGDocumentImpl(const SVGDocumentImpl&) = delete;
+    SVGDocumentImpl& operator=(const SVGDocumentImpl&) = delete;
+
+    SVGDocumentImpl(SVGDocumentImpl&&) = delete;
+    SVGDocumentImpl& operator=(SVGDocumentImpl&&) = delete;
+
+    ~SVGDocumentImpl()
+    {
+        resvg_tree_destroy(m_tree);
+        m_tree = nullptr;
+    }
+
     [[nodiscard]] Size get_size() const noexcept override
     {
         const auto size = resvg_get_image_size(m_tree);


### PR DESCRIPTION
This gets text working when rendering SVG documents.

resvg implements its own text rendering, and text support requires loading system fonts into an internal database. Loading those fonts isn't that fast, and is unnecessary for SVG documents that don't contain text. Hence, here resvg is only made to load system fonts when an SVG document containing the characters `<text` is encountered. This is a workaround, as resvg doesn't have similar native functionality to conditionally load fonts.

Note that, though not advertised in the SVG services API, technically resvg supports gzip-compressed SVGs. Text support remains disabled for these.