### PR TITLE
Update SDK #include and README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ abort_callback_dummy aborter;
 const auto render_height = 512;
 const auto render_width = 512;
 const auto file_path = "R(c:\path\to\svg\file)";
+
+svg_services::svg_services::ptr svg_api;
+
+if (!fb2k::std_api_try_get(svg_api)) {
+    // Handle the case when the API isn’t available
+}
+
 const auto svg_data = filesystem::g_readWholeFile(file_path, 10'000'000, aborter);
 
 std::vector<uint8_t> bitmap_data(

--- a/api/api.h
+++ b/api/api.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <foobar2000/SDK/foobar2000.h>
+#include <SDK/foobar2000-lite.h>
 
 namespace svg_services {
 

--- a/foo_svg_services/foo_svg_services.vcxproj
+++ b/foo_svg_services/foo_svg_services.vcxproj
@@ -122,7 +122,7 @@
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <AdditionalOptions>/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalIncludeDirectories>..</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..;..\foobar2000</AdditionalIncludeDirectories>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -173,7 +173,7 @@
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <AdditionalOptions>/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalIncludeDirectories>..</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..;..\foobar2000</AdditionalIncludeDirectories>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -222,7 +222,7 @@
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <AdditionalOptions>/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalIncludeDirectories>..</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..;..\foobar2000</AdditionalIncludeDirectories>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -268,7 +268,7 @@
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <AdditionalOptions>/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalIncludeDirectories>..</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..;..\foobar2000</AdditionalIncludeDirectories>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>


### PR DESCRIPTION
This updates the #include of the foobar2000 SDK in `api.h` for consistency with examples in the foobar2000 SDK itself.

It also adds a few missing lines to the usage example in the README.