### PR TITLE
Update ClangFormat configuration

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,22 +2,44 @@
 Language: Cpp
 AccessModifierOffset: -4
 AlignAfterOpenBracket: DontAlign
-AlignConsecutiveMacros: None
-AlignConsecutiveAssignments: None
-AlignConsecutiveBitFields: None
-AlignConsecutiveDeclarations: None
+AlignArrayOfStructures: None
+AlignConsecutiveAssignments:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: false
+  PadOperators: true
+AlignConsecutiveBitFields:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: false
+  PadOperators: true
+AlignConsecutiveDeclarations:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: false
+  PadOperators: true
+AlignConsecutiveMacros:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: false
+  PadOperators: true
 AlignEscapedNewlines: Left
 AlignOperands: DontAlign
-AlignTrailingComments: false
+AlignTrailingComments:
+  Kind: Never
+  OverEmptyLines: 0
 AllowAllArgumentsOnNextLine: true
-AllowAllConstructorInitializersOnNextLine: false
 AllowAllParametersOfDeclarationOnNextLine: true
-AllowShortEnumsOnASingleLine: true
 AllowShortBlocksOnASingleLine: Empty
 AllowShortCaseLabelsOnASingleLine: false
+AllowShortEnumsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: Inline
-AllowShortLambdasOnASingleLine: All
 AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: All
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
@@ -27,17 +49,18 @@ AttributeMacros:
   - __capability
 BinPackArguments: true
 BinPackParameters: true
+BitFieldColonSpacing: Both
 BraceWrapping:
   AfterCaseLabel: false
   AfterClass: false
   AfterControlStatement: Never
   AfterEnum: false
+  AfterExternBlock: false
   AfterFunction: true
   AfterNamespace: false
   AfterObjCDeclaration: false
   AfterStruct: false
   AfterUnion: false
-  AfterExternBlock: false
   BeforeCatch: false
   BeforeElse: false
   BeforeLambdaBody: false
@@ -46,26 +69,26 @@ BraceWrapping:
   SplitEmptyFunction: true
   SplitEmptyRecord: true
   SplitEmptyNamespace: true
-BreakBeforeBinaryOperators: All
-BreakBeforeConceptDeclarations: true
-BreakBeforeBraces: Custom
-BreakBeforeInheritanceComma: false
-BreakInheritanceList: BeforeComma
-BreakBeforeTernaryOperators: true
-BreakConstructorInitializersBeforeComma: false
-BreakConstructorInitializers: BeforeComma
+BreakAfterAttributes: Never
 BreakAfterJavaFieldAnnotations: false
+BreakArrays: true
+BreakBeforeBinaryOperators: All
+BreakBeforeConceptDeclarations: Always
+BreakBeforeBraces: Custom
+BreakBeforeInlineASMColon: OnlyMultiline
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeComma
+BreakInheritanceList: BeforeComma
 BreakStringLiterals: true
 ColumnLimit: 120
 CommentPragmas: "^ IWYU pragma:"
 CompactNamespaces: false
-ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
-DeriveLineEnding: true
 DerivePointerAlignment: false
 DisableFormat: false
+EmptyLineAfterAccessModifier: Never
 EmptyLineBeforeAccessModifier: LogicalBlock
 ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: true
@@ -73,8 +96,8 @@ ForEachMacros:
   - foreach
   - Q_FOREACH
   - BOOST_FOREACH
-StatementAttributeLikeMacros:
-  - Q_EMIT
+IfMacros:
+  - KJ_IF_MAYBE
 IncludeBlocks: Preserve
 IncludeCategories:
   - Regex: '^<ext/.*\.h>'
@@ -95,18 +118,30 @@ IncludeCategories:
     CaseSensitive: false
 IncludeIsMainRegex: "([-_](test|unittest))?$"
 IncludeIsMainSourceRegex: ""
-IndentCaseLabels: false
+IndentAccessModifiers: false
 IndentCaseBlocks: false
+IndentCaseLabels: false
+IndentExternBlock: AfterExternBlock
 IndentGotoLabels: true
 IndentPPDirectives: None
-IndentExternBlock: AfterExternBlock
-IndentRequires: false
+IndentRequiresClause: false
 IndentWidth: 4
 IndentWrappedFunctionNames: false
+InsertBraces: false
+InsertNewlineAtEOF: false
 InsertTrailingCommas: None
+IntegerLiteralSeparator:
+  Binary: 0
+  BinaryMinDigits: 0
+  Decimal: 3
+  DecimalMinDigits: 5
+  Hex: 0
+  HexMinDigits: 0
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true
 KeepEmptyLinesAtTheStartOfBlocks: false
+LambdaBodyIndentation: Signature
+LineEnding: DeriveLF
 MacroBlockBegin: ""
 MacroBlockEnd: ""
 MaxEmptyLinesToKeep: 1
@@ -116,52 +151,76 @@ ObjCBlockIndentWidth: 4
 ObjCBreakBeforeNestedBlockParam: true
 ObjCSpaceAfterProperty: true
 ObjCSpaceBeforeProtocolList: true
+PackConstructorInitializers: CurrentLine
 PenaltyBreakAssignment: 2
 PenaltyBreakBeforeFirstCallParameter: 19
 PenaltyBreakComment: 300
 PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
 PenaltyBreakString: 1000
 PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
-PenaltyReturnTypeOnItsOwnLine: 60
 PenaltyIndentedWhitespace: 0
+PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Left
+PPIndentWidth: -1
+QualifierAlignment: Leave
+ReferenceAlignment: Pointer
 ReflowComments: true
-SortIncludes: false
+RemoveBracesLLVM: false
+RemoveSemicolon: true
+RequiresClausePosition: OwnLine
+RequiresExpressionIndentation: OuterScope
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SortIncludes: Never
 SortJavaStaticImport: Before
-SortUsingDeclarations: true
+SortUsingDeclarations: LexicographicNumeric
 SpaceAfterCStyleCast: false
 SpaceAfterLogicalNot: false
 SpaceAfterTemplateKeyword: true
+SpaceAroundPointerQualifiers: Default
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeCaseColon: false
 SpaceBeforeCpp11BracedList: false
 SpaceBeforeCtorInitializerColon: true
 SpaceBeforeInheritanceColon: true
 SpaceBeforeParens: ControlStatements
-SpaceAroundPointerQualifiers: Default
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros: true
+  AfterOverloadedOperator: false
+  AfterRequiresInClause: false
+  AfterRequiresInExpression: false
+  BeforeNonEmptyParentheses: false
 SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
 SpaceInEmptyBlock: false
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 1
-SpacesInAngles: false
+SpacesInAngles: Never
 SpacesInConditionalStatement: false
 SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum: 1
+  Maximum: -1
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-SpaceBeforeSquareBrackets: false
-BitFieldColonSpacing: Both
 Standard: c++20
+StatementAttributeLikeMacros:
+  - Q_EMIT
 StatementMacros:
   - Q_UNUSED
   - QT_REQUIRE_VERSION
 TabWidth: 4
-UseCRLF: false
 UseTab: Never
 WhitespaceSensitiveMacros:
-  - STRINGIZE
-  - PP_STRINGIZE
   - BOOST_PP_STRINGIZE
-  - NS_SWIFT_NAME
   - CF_SWIFT_NAME
+  - NS_SWIFT_NAME
+  - PP_STRINGIZE
+  - STRINGIZE

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,19 +6,19 @@ exclude: |
   )$
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.7.1
+    rev: v3.0.1
     hooks:
       - id: prettier
         types_or: [json, markdown, yaml]
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v14.0.6
+    rev: v16.0.6
     hooks:
       - id: clang-format
         types_or: [c++]

--- a/api/api.h
+++ b/api/api.h
@@ -4,83 +4,79 @@
 
 namespace svg_services {
 
-PFC_DECLARE_EXCEPTION(exception_svg_services, pfc::exception,
-                      "SVG services error");
+PFC_DECLARE_EXCEPTION(exception_svg_services, pfc::exception, "SVG services error");
 
 struct Size {
-  double width{};
-  double height{};
+    double width{};
+    double height{};
 };
 
 struct Rect {
-  double x{};
-  double y{};
-  double width{};
-  double height{};
+    double x{};
+    double y{};
+    double width{};
+    double height{};
 };
 
 enum class PixelFormat {
-  BGRA,
-  PRGBA,
-  PBGRA,
+    BGRA,
+    PRGBA,
+    PBGRA,
 };
 
 enum class ScalingMode {
-  None,
-  Fit,
-  Zoom,
-  Stretch,
+    None,
+    Fit,
+    Zoom,
+    Stretch,
 };
 
 enum class Position {
-  TopLeft,
-  Centred,
+    TopLeft,
+    Centred,
 };
 
 class NOVTABLE svg_document : public service_base {
 public:
-  [[nodiscard]] virtual Size get_size() const noexcept = 0;
+    [[nodiscard]] virtual Size get_size() const noexcept = 0;
 
-  [[nodiscard]] virtual Rect get_view_box() const noexcept = 0;
+    [[nodiscard]] virtual Rect get_view_box() const noexcept = 0;
 
-  /**
-   * \brief Render the SVG document
-   *
-   * \param output_width The width of the output bitmap
-   * \param output_height The height of the output bitmap
-   * \param position Where to position the rendered SVG in the output bitmap
-   * \param scaling_mode The scaling mode to use to fit the SVG to the output
-   * \param output_pixel_format The pixel format to render the SVG in
-   * bitmap \param output_buffer Pointer to a writable buffer of at least size
-   *                      render_width * render_height * 4.
-   *                      This will receive a 32-bpp bitmap.
-   * \param output_buffer_size Size of the output buffer in bytes
-   */
-  virtual void render(int output_width, int output_height, Position position,
-                      ScalingMode scaling_mode, PixelFormat output_pixel_format,
-                      void *output_buffer, size_t output_buffer_size) const = 0;
+    /**
+     * \brief Render the SVG document
+     *
+     * \param output_width The width of the output bitmap
+     * \param output_height The height of the output bitmap
+     * \param position Where to position the rendered SVG in the output bitmap
+     * \param scaling_mode The scaling mode to use to fit the SVG to the output
+     * \param output_pixel_format The pixel format to render the SVG in
+     * bitmap \param output_buffer Pointer to a writable buffer of at least size
+     *                      render_width * render_height * 4.
+     *                      This will receive a 32-bpp bitmap.
+     * \param output_buffer_size Size of the output buffer in bytes
+     */
+    virtual void render(int output_width, int output_height, Position position, ScalingMode scaling_mode,
+        PixelFormat output_pixel_format, void* output_buffer, size_t output_buffer_size) const
+        = 0;
 
-  FB2K_MAKE_SERVICE_INTERFACE(svg_document, service_base);
+    FB2K_MAKE_SERVICE_INTERFACE(svg_document, service_base);
 };
 
 class NOVTABLE svg_services : public service_base {
 public:
-  /**
-   * \brief Open an SVG document
-   *
-   * \param svg_data Pointer to a buffer containing the SVG document
-   *
-   * \param svg_data_size Size of the SVG data in the buffer in bytes
-   */
-  virtual svg_document::ptr open(const void *svg_data,
-                                 size_t svg_data_size) const = 0;
+    /**
+     * \brief Open an SVG document
+     *
+     * \param svg_data Pointer to a buffer containing the SVG document
+     *
+     * \param svg_data_size Size of the SVG data in the buffer in bytes
+     */
+    virtual svg_document::ptr open(const void* svg_data, size_t svg_data_size) const = 0;
 
-  FB2K_MAKE_SERVICE_INTERFACE_ENTRYPOINT(svg_services)
+    FB2K_MAKE_SERVICE_INTERFACE_ENTRYPOINT(svg_services)
 };
 
-DECLARE_CLASS_GUID(svg_document, 0x9d367cb6, 0x50ca, 0x4511, 0xa0, 0x2f, 0x9f,
-                   0x57, 0x3f, 0x9a, 0x2a, 0x33);
-DECLARE_CLASS_GUID(svg_services, 0x8953198d, 0xf39d, 0x4186, 0xa9, 0xa3, 0xe5,
-                   0xa6, 0x7c, 0xa6, 0x14, 0xa1);
+DECLARE_CLASS_GUID(svg_document, 0x9d367cb6, 0x50ca, 0x4511, 0xa0, 0x2f, 0x9f, 0x57, 0x3f, 0x9a, 0x2a, 0x33);
+DECLARE_CLASS_GUID(svg_services, 0x8953198d, 0xf39d, 0x4186, 0xa9, 0xa3, 0xe5, 0xa6, 0x7c, 0xa6, 0x14, 0xa1);
 
 } // namespace svg_services


### PR DESCRIPTION
This updates the ClangFormat configuration to match https://github.com/reupen/columns_ui/pull/789.

The configuration file was also moved to the repository root so that the `api` directory is formatted correctly.