### PR TITLE
Add auto-merge GitHub Actions workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,15 @@
+name: Auto-merge pull requests
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Enable auto-merge
+    uses: reupen/github-actions/.github/workflows/auto-merge.yml@v1
+    with:
+      excluded-dependencies: resvg


### PR DESCRIPTION
This adds a workflow to enable auto-merge on Dependabot pull requests (excluding for resvg) and on pre-commit pull requests without auto-fixes.