### PR TITLE
Don’t fail resvg build on warnings on GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           rust-src-dir: resvg
+          rustflags: ""
           target: ${{ matrix.platform == 'win32' && 'i686-pc-windows-msvc' || '' }}
 
       - name: Build resvg


### PR DESCRIPTION
It seems that resvg compiles with the following warning with Rust 1.94:

```
warning: a method with this name may be added to the standard library in the future
  --> crates\resvg\src\filter\iir_blur.rs:61:25
   |
61 |     let data = src.data.as_mut_slice();
   |                         ^^^^^^^^^^^^
   |
   = warning: once this associated item is added to the standard library, the ambiguity may cause an error or change in behavior!
   = note: for more information, see issue #48919 <https://github.com/rust-lang/rust/issues/48919>
   = help: call with fully qualified syntax `as_mut_slice(...)` to keep using the current method
   = note: `#[warn(unstable_name_collisions)]` (part of `#[warn(future_incompatible)]`) on by default
```

This change stops `actions-rust-lang/setup-rust-toolchain` overriding `RUSTFLAGS` so that the build doesn’t fail due to that warning.

Once the problem is fixed in resvg, this change can be reverted.