### PR TITLE
Update GSL

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Set up vcpkg
         run: |
-          git -C C:\vcpkg fetch
+          git -C C:\vcpkg pull
           vcpkg version
           vcpkg integrate install
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,12 +1,12 @@
 {
   "name": "svg-services",
   "version-string": "git",
-  "builtin-baseline": "03ca9b59af1506a86840e3a3a01a092f3333a29b",
+  "builtin-baseline": "927f62e4b8838bd7e441e9c45103a16ffd75007e",
   "dependencies": ["ms-gsl"],
   "overrides": [
     {
       "name": "ms-gsl",
-      "version-string": "3.1.0#1"
+      "version-string": "4.2.2"
     }
   ]
 }


### PR DESCRIPTION
This updates GSL to version 4.2.2 to fix a compiler warning preventing compilation with the latest VS 2026 toolset.