### PR TITLE
Enable cargo-about cli feature on GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Collect resvg licences
         run: |
-          cargo install cargo-about
+          cargo install cargo-about --features cli
           .\collect-resvg-licences.ps1
 
       - name: Build


### PR DESCRIPTION
This fixes the failing GitHub Actions build due to the cli feature not being enabled when installing cargo-about.